### PR TITLE
Updated MySQLite

### DIFF
--- a/mysqlite.lua
+++ b/mysqlite.lua
@@ -237,6 +237,7 @@ function format.insert(id,tab)
     for k,v in pairs(tab) do
         if start then --There are already vars
             VALUES_str = VALUES_str .. string.format(",`%s`", k)
+			VALUES = VALUES .. "," .. SQLStr(v)
         else
             VALUES_str = VALUES_str .. string.format("`%s`", k)
             VALUES = VALUES .. SQLStr(v)

--- a/mysqlite.lua
+++ b/mysqlite.lua
@@ -12,7 +12,7 @@
     - MySQLOO
     - tmysql4
 
-    Note: When both MySQLOO and tmysql4 modules are installed, MySQLOO is used by default.
+    Note: When both MySQLOO and tmysql4 modules are installed, tmysql4 is used by default.
 
     /*---------------------------------------------------------------------------
     Documentation
@@ -129,18 +129,14 @@ local function loadMySQLModule()
     end
     moduleLoaded = true
 
-    require(moo and tmsql and MySQLite_config.Preferred_module or
-            moo and "mysqloo"                                  or
-            "tmysql4")
-
-
+    require(moo and tmsql and MySQLite_config.Preferred_module 
+    or tmsql and "tmysql4" or moo and "mysqloo")
     mysqlOO = mysqloo
     TMySQL = tmysql
 end
 loadMySQLModule()
 
 module("MySQLite")
-
 
 function initialize(config)
     MySQLite_config = config or MySQLite_config
@@ -347,16 +343,16 @@ end
 
 function query(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and
-            mysqlOO and msOOQuery or
-            TMySQL and tmsqlQuery) or
+            TMySQL and tmsqlQuery or
+            mysqlOO and msOOQuery) or
         SQLiteQuery
     return qFunc(sqlText, callback, errorCallback, false)
 end
 
 function queryValue(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and
-            mysqlOO and msOOQuery or
-            TMySQL and tmsqlQuery) or
+            TMySQL and tmsqlQuery or
+            mysqlOO and msOOQuery) or
         SQLiteQuery
     return qFunc(sqlText, callback, errorCallback, true)
 end
@@ -405,15 +401,15 @@ end
 
 function connectToMySQL(host, username, password, database_name, database_port)
     database_port = database_port or 3306
-    local func = mysqlOO and msOOConnect or TMySQL and tmsqlConnect or function() end
+    local func = TMySQL and tmsqlConnect or mysqlOO and msOOConnect  or function() end
     func(host, username, password, database_name, database_port)
 end
 
 function SQLStr(str)
     local escape =
         not CONNECTED_TO_MYSQL and sql.SQLStr or
-        mysqlOO                and function(str) return '"' .. databaseObject:escape(tostring(str)) .. '"' end or
-        TMySQL                 and function(str) return '"' .. databaseObject:Escape(tostring(str)) .. '"' end
+        TMySQL                 and function(str) return '"' .. databaseObject:Escape(tostring(str)) .. '"' end or
+        mysqlOO                and function(str) return '"' .. databaseObject:escape(tostring(str)) .. '"' end 
 
     return escape(str)
 end

--- a/mysqlite.lua
+++ b/mysqlite.lua
@@ -125,7 +125,7 @@ local function loadMySQLModule()
     moo, tmsql = file.Exists("bin/gmsv_mysqloo_*.dll", "LUA"), file.Exists("bin/gmsv_tmysql4_*.dll", "LUA")
 
     if not moo and not tmsql then
-        error("Could not find a suitable MySQL module. Supported modules are MySQLOO and tmysql4.\n")
+        error("Could not find a suitable MySQL module. Supported modules are MySQLOO and tmysql4.")
     end
     moduleLoaded = true
 
@@ -237,7 +237,7 @@ function format.insert(id,tab)
     for k,v in pairs(tab) do
         if start then --There are already vars
             VALUES_str = VALUES_str .. string.format(",`%s`", k)
-			VALUES = VALUES .. "," .. SQLStr(v)
+            VALUES = VALUES .. "," .. SQLStr(v)
         else
             VALUES_str = VALUES_str .. string.format("`%s`", k)
             VALUES = VALUES .. SQLStr(v)


### PR DESCRIPTION
Added format.insert and format.update for easier operations.
timer.Exists is excess.
Destroy -> Remove
Changed tabs to spaces.
Using TMySQL4 by default.

First of all, i added helpers, what can turn this
![2015-09-03_16-21_garry s mod](https://cloud.githubusercontent.com/assets/6339511/9654911/051f973a-5258-11e5-9bfa-ac3479d56ac9.jpg)
Second, i changed all tabs to spaces (what you want)

And for the end, i forced to use TMySQL4 by default. Why?
MySQLOO has VERY poor prefomance.
When running many queries at once, server will be lagging before all queries is finished.
When using InnoDB and innodb_flush_log_at_trx_commit = 1 server will be locked up before query is finished (many quieries at once (not so much, about 90-150) can cause server locked up permanently)

Test results:
100 queries, TMySQL4 and MySQLOO no lag.
1000 queries, TMySQL4 server lag for 100 ms, MySQLOO server lag for 1,2 seconds.
10000 queries, TMySQL server lag for 207 ms, MySQLOO server lag for 3 seconds, and server was lagging for about 20 seconds before queries is finished.
100000 queries, TMySQL4 server lag for 616 ms, MySQLOO server lag for 10!!! seconds, and server was lagging more than 2 minutes.
In all test before running queries table was truncated.
In all test used this query ``` INSERT INTO test (id,text) VALUES (NULL,'example'); ```