### PR TITLE
Fixed error

### DIFF
--- a/mysqlite.lua
+++ b/mysqlite.lua
@@ -307,18 +307,12 @@ local function SQLiteQuery(sqlText, callback, errorCallback, queryValue)
 end
 
 function query(sqlText, callback, errorCallback)
-    local qFunc = (CONNECTED_TO_MYSQL and
-            mysqlOO and msOOQuery or
-            TMySQL and tmsqlQuery) or
-        SQLiteQuery
+    local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
     return qFunc(sqlText, callback, errorCallback, false)
 end
 
 function queryValue(sqlText, callback, errorCallback)
-    local qFunc = (CONNECTED_TO_MYSQL and
-            mysqlOO and msOOQuery or
-            TMySQL and tmsqlQuery) or
-        SQLiteQuery
+    local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
     return qFunc(sqlText, callback, errorCallback, true)
 end
 


### PR DESCRIPTION
I was having this error on my server while using MySQLite:

```
[ERROR] addons/_bwhitelist-revamped-1/lua/includes/modules/bwhitelist_mysqlite.lua:289: attempt to index global 'databaseObject' (a nil value)
  1. query - addons/_bwhitelist-revamped-1/lua/includes/modules/bwhitelist_mysqlite.lua:289
   2. unknown - BWhitelist:452
    3. RunString - [C]:-1
     4. onsuccess - MoonDRM Core:2
      5. unknown - lua/includes/modules/http.lua:64
```

EnableMySQL was set to false in the config but it kept trying to make a tmysql4 query.

I don't know why it was ignoring EnableMySQL but I simply fixed it by adding a few brackets into the logic of the query function

It looks pretty shit but it works so if you want to correct it afterwards go ahead